### PR TITLE
ignore dask worker space

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,5 +103,6 @@ venv.bak/
 # mypy
 .mypy_cache/
 dask-worker.*
+dask-worker-space/
 *.nc
 .DS_Store


### PR DESCRIPTION
Is this the right spot to put the dask-worker-space/ @andersy005 ? I see there is an organization to the .gitignore file but am not sure if I followed it.