### PR TITLE
Comment out filter paths until notebooks all run

### DIFF
--- a/.github/workflows/binderbot.yaml
+++ b/.github/workflows/binderbot.yaml
@@ -1,25 +1,26 @@
 name: Binderbot
 on:
   # Trigger the workflow on push or pull request,
-  # but only for the main branch
+  # but only for the main branch.  Comment out filter paths to 
+  # push non-running notebooks to pangeo-gallery.
   push:
     branches:
       - main
-    paths:
-      - 'notebooks/Run-Anywhere/**/*.ipynb'
-      - 'binder-gallery.yaml'
-      - 'thumbnail.png'
-      - '.github/workflows/binderbot.yaml'
-      - '.binder/**'
+    #paths:
+    #  - 'notebooks/Run-Anywhere/**/*.ipynb'
+    #  - 'binder-gallery.yaml'
+    #  - 'thumbnail.png'
+    #  - '.github/workflows/binderbot.yaml'
+    #  - '.binder/**'
   pull_request:
     branches:
       - main
-    paths:
-      - 'notebooks/Run-Anywhere/**/*.ipynb'
-      - 'binder-gallery.yaml'
-      - 'thumbnail.png'
-      - '.github/workflows/binderbot.yaml'
-      - '.binder/**'
+    #paths:
+    #  - 'notebooks/Run-Anywhere/**/*.ipynb'
+    #  - 'binder-gallery.yaml'
+    #  - 'thumbnail.png'
+    #  - '.github/workflows/binderbot.yaml'
+    #  - '.binder/**'
 jobs:
   build:
     name: Binderbot Build


### PR DESCRIPTION

Binderbot currently has a bug that prevents one of the notebooks from running.   We comment out the filter paths in order to have this notebook rendered and added to pangeo-gallery without running it.